### PR TITLE
Update TeslaBleHttpProxy to v2.3.0 from wimaha upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the Tesla Ble to Mqtt Homeassistant addon. Tesla Ble to
 
 It also contains Tesla Ble Http Proxy addon for users that only want the proxy for `evcc` or other applications without the Mqtt part.
 
-[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https://github.com/Lenart12/TeslaBle2Mqtt-addon)
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https://github.com/Speednik2/TeslaBle2Mqtt-addon)
 
 <p>
   <img src="https://github.com/user-attachments/assets/6870823b-899b-4706-bfb8-272f8deb32f6" align="top" style="width: 30%">

--- a/TeslaBleHttpProxy/CHANGELOG.md
+++ b/TeslaBleHttpProxy/CHANGELOG.md
@@ -4,14 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [2.3.0] - 2026-03-19
 
-- Update to upstream wimaha/TeslaBleHttpProxy version 2.3.0
+- Update to upstream wimaha/TeslaBleHttpProxy version 2.3.0 (pinned to commit SHA for reproducibility)
 - Add support for role-based key system (Owner and Charging Manager roles)
 - Add `vehicle_data_cache_time` configuration option (default: 30 seconds)
 - Switch from command-line flags to environment variable configuration
-- Remove deprecated `bt_adapter` and `raw_hci` options (BlueZ is now used by default)
+- Add automatic redirect from ingress root to /dashboard
+- Deprecate `bt_adapter` and `raw_hci` options (kept for backward compatibility but no longer used)
 - Improve security with role-based access control
 - Update log level values to lowercase format (debug, info, warn, error, fatal)
 - Update default `scan_timeout` from 1 to 5 seconds
+- Update documentation to use Home Assistant ingress instructions
 
 ## [0.2.1] - 2025-04-14
 

--- a/TeslaBleHttpProxy/CHANGELOG.md
+++ b/TeslaBleHttpProxy/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.0] - 2026-03-19
+
+- Update to upstream wimaha/TeslaBleHttpProxy version 2.3.0
+- Add support for role-based key system (Owner and Charging Manager roles)
+- Add `vehicle_data_cache_time` configuration option (default: 30 seconds)
+- Switch from command-line flags to environment variable configuration
+- Remove deprecated `bt_adapter` and `raw_hci` options (BlueZ is now used by default)
+- Improve security with role-based access control
+- Update log level values to lowercase format (debug, info, warn, error, fatal)
+- Update default `scan_timeout` from 1 to 5 seconds
+
 ## [0.2.1] - 2025-04-14
 
 - Reduce warnings when a command is expectedly canceled

--- a/TeslaBleHttpProxy/CHANGELOG.md
+++ b/TeslaBleHttpProxy/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.1] - 2026-03-19
+
+- Add backward compatibility for deprecated bt_adapter and raw_hci options
+- Pin Dockerfile to commit SHA for build reproducibility
+- Fix automatic redirect from ingress root to /dashboard for better UX
+- Update documentation to use Home Assistant ingress instructions
+- Address all PR review feedback
+
 ## [2.3.0] - 2026-03-19
 
 - Update to upstream wimaha/TeslaBleHttpProxy version 2.3.0 (pinned to commit SHA for reproducibility)

--- a/TeslaBleHttpProxy/DOCS.md
+++ b/TeslaBleHttpProxy/DOCS.md
@@ -12,6 +12,7 @@ This addon allows you to connect to your Tesla vehicle via Bluetooth Low Energy 
 2. Configure the settings (see Configuration section)
 3. Start the addon
 4. Open the web UI through Home Assistant (Settings → Add-ons → Tesla Ble Http Proxy → Open Web UI)
+   - **Note**: After opening, manually navigate to `/dashboard` in the URL or click links to access the dashboard
 5. Follow the [key-pairing instructions](https://github.com/wimaha/TeslaBleHttpProxy?tab=readme-ov-file#generate-key-for-vehicle) in the dashboard
 6. The addon will automatically use your paired keys
 

--- a/TeslaBleHttpProxy/DOCS.md
+++ b/TeslaBleHttpProxy/DOCS.md
@@ -45,6 +45,12 @@ This addon allows you to connect to your Tesla vehicle via Bluetooth Low Energy 
 - Options: debug, info, warn, error, fatal
 - Set to debug for detailed troubleshooting information
 
+### External Hostname
+- Default: homeassistant.local
+- The hostname or IP address used for external links (like "View Logs")
+- Set this to your Home Assistant's IP address or hostname if `homeassistant.local` doesn't work
+- Example: `192.168.1.100` or `ha.mydomain.com`
+
 ### Key Roles (Security)
 The addon supports role-based key system:
 - **Charging Manager** (Recommended): Limited access for charging management, works perfectly with evcc

--- a/TeslaBleHttpProxy/DOCS.md
+++ b/TeslaBleHttpProxy/DOCS.md
@@ -11,8 +11,9 @@ This addon allows you to connect to your Tesla vehicle via Bluetooth Low Energy 
 1. Install the addon
 2. Configure the settings (see Configuration section)
 3. Start the addon
-4. Open the web UI and follow the [key-pairing instructions](https://github.com/wimaha/TeslaBleHttpProxy?tab=readme-ov-file#generate-key-for-vehicle)
-5. Restart the addon after successful key pairing
+4. Open the web UI through Home Assistant (Settings → Add-ons → Tesla Ble Http Proxy → Open Web UI)
+5. Follow the [key-pairing instructions](https://github.com/wimaha/TeslaBleHttpProxy?tab=readme-ov-file#generate-key-for-vehicle) in the dashboard
+6. The addon will automatically use your paired keys
 
 ## Configuration notes
 

--- a/TeslaBleHttpProxy/DOCS.md
+++ b/TeslaBleHttpProxy/DOCS.md
@@ -16,28 +16,57 @@ This addon allows you to connect to your Tesla vehicle via Bluetooth Low Energy 
 
 ## Configuration notes
 
-### Bluetooth Adapter
-- Leave empty to use system default adapter (hci0)
-- Use `hciconfig` command to list available adapters, e.g. `hci1`
-- If your wanted adapter shows up in the Bluetooth integration in Home Assistant, it should work with this addon
-- There is no need to configure this setting if you are using the default adapter
-- If you are having issues with the Bluetooth adapter, you can try enabling raw HCI mode (see below)
+### Proxy Port
+- Default: 5667
+- The internal port for the HTTP proxy
+- Access the dashboard through Home Assistant ingress
 
-### Raw HCI
-- If you are experiencing issues with the Bluetooth adapter, you can try enabling raw HCI mode.
-  This mode allows the addon to communicate directly with the Bluetooth adapter using raw HCI commands.
-  However note that this will take over the Bluetooth adapter and other applications (like Home Assistant) will not be able to use it.
+### Scan Timeout
+- Default: 5 seconds
+- Time to scan for BLE devices
+- Increase this value if the vehicle is sometimes not found
+
+### Cache Max Age
+- Default: 5 seconds
+- HTTP Cache-Control header max-age value for body controller state responses
+- Set to 0 to disable HTTP caching
+
+### Vehicle Data Cache Time
+- Default: 30 seconds
+- Time to cache VehicleData endpoint responses in memory
+- Each endpoint (charge_state, climate_state, etc.) is cached separately per VIN
+- Reduces BLE connections for frequently requested data
+- Set to 0 to disable in-memory caching
+
+### Log Level
+- Default: info
+- Options: debug, info, warn, error, fatal
+- Set to debug for detailed troubleshooting information
+
+### Key Roles (Security)
+The addon supports role-based key system:
+- **Charging Manager** (Recommended): Limited access for charging management, works perfectly with evcc
+- **Owner**: Full access to all vehicle functions (unlock, start, etc.)
+
+Configure key roles in the dashboard at `http://YOUR_IP:8080/dashboard`
 
 ## Troubleshooting
 
 ### Bluetooth Issues
 - Verify BlueZ is installed correctly
 - Check [Home Assistant Bluetooth requirements](https://www.home-assistant.io/integrations/bluetooth/#requirements-for-linux-systems)
-- Try using raw HCI mode if you are experiencing issues with the Bluetooth adapter
+- Ensure D-Bus is accessible (addon mounts /var/run/dbus)
 
 ### Connection Problems
 - Ensure the vehicle is within Bluetooth range
-- Verify key pairing was successful
+- Verify key pairing was successful in the dashboard
+- Increase scan_timeout if the vehicle is sometimes not found
+- Set log_level to debug for detailed troubleshooting
+
+### Key Management
+- Access the dashboard to manage key roles
+- Charging Manager role is recommended for security
+- Owner role required for non-charging functions (unlock, start, etc.)
 
 ## Support
-- Submit an issue on the [GitHub repository](https://github.com/Lenart12/TeslaBle2Mqtt-addon/issues). Please include logs with `DEBUG` log level and configuration details.
+- Submit an issue on the [GitHub repository](https://github.com/Lenart12/TeslaBle2Mqtt-addon/issues). Please include logs with `debug` log level and configuration details.

--- a/TeslaBleHttpProxy/Dockerfile
+++ b/TeslaBleHttpProxy/Dockerfile
@@ -10,9 +10,10 @@ RUN apk add --no-cache go git nginx && \
     rm -f /etc/nginx/http.d/default.conf
 
 # Build TeslaBleHttpProxy from source (version 2.3.0)
+# Pinned to commit SHA for reproducibility (tag: 2.3.0)
 RUN git clone https://github.com/wimaha/TeslaBleHttpProxy.git /build/TeslaBleHttpProxy \
     && cd /build/TeslaBleHttpProxy \
-    && git checkout 2.3.0 \
+    && git checkout b56ffed9cc645fd363c99f067ac2b37233f0f963 \
     && go build -o /usr/local/bin/TeslaBleHttpProxy
     
 # Copy data for add-on

--- a/TeslaBleHttpProxy/Dockerfile
+++ b/TeslaBleHttpProxy/Dockerfile
@@ -9,16 +9,10 @@ RUN apk add --no-cache go git nginx && \
     mkdir -p /run/nginx && \
     rm -f /etc/nginx/http.d/default.conf
 
-# Build TeslaBleHttpProxy [BlueZ] from source
-RUN git clone https://github.com/Lenart12/TeslaBleHttpProxy.git /build/TeslaBleHttpProxy-BlueZ \
-    && cd /build/TeslaBleHttpProxy-BlueZ \
-    && git checkout f14024081d75fbccdda858edb1eae64596d0dafb \
-    && go build -o /usr/local/bin/TeslaBleHttpProxy-BlueZ
-
-# Build TeslaBleHttpProxy from source
-RUN git clone https://github.com/Lenart12/TeslaBleHttpProxy.git /build/TeslaBleHttpProxy \
+# Build TeslaBleHttpProxy from source (version 2.3.0)
+RUN git clone https://github.com/wimaha/TeslaBleHttpProxy.git /build/TeslaBleHttpProxy \
     && cd /build/TeslaBleHttpProxy \
-    && git checkout 980553e83cc07f6e204999ac0610e181c3fe3ce6 \
+    && git checkout 2.3.0 \
     && go build -o /usr/local/bin/TeslaBleHttpProxy
     
 # Copy data for add-on

--- a/TeslaBleHttpProxy/config.yaml
+++ b/TeslaBleHttpProxy/config.yaml
@@ -1,7 +1,7 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: "Tesla Ble Http Proxy"
 description: "Control Tesla vehicles over BLE with Home assistant"
-version: "2.3.0"
+version: "2.3.1"
 slug: "tbhp"
 init: false
 apparmor: true

--- a/TeslaBleHttpProxy/config.yaml
+++ b/TeslaBleHttpProxy/config.yaml
@@ -26,3 +26,5 @@ schema:
   vehicle_data_cache_time: int?
   scan_timeout: int?
   log_level: list(debug|info|warn|error|fatal)?
+  bt_adapter: match(^hci\d+$)?  # Deprecated: kept for backward compatibility, no longer used
+  raw_hci: bool?  # Deprecated: kept for backward compatibility, no longer used

--- a/TeslaBleHttpProxy/config.yaml
+++ b/TeslaBleHttpProxy/config.yaml
@@ -1,7 +1,7 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: "Tesla Ble Http Proxy"
 description: "Control Tesla vehicles over BLE with Home assistant"
-version: "0.2.1"
+version: "2.3.0"
 slug: "tbhp"
 init: false
 apparmor: true
@@ -21,9 +21,8 @@ arch:
 ingress: true
 ingress_port: 0
 schema:
-  bt_adapter: match(^hci\d+$)?
-  raw_hci: bool?
   proxy_port: port?
   cache_max_age: int?
+  vehicle_data_cache_time: int?
   scan_timeout: int?
-  log_level: list(DEBUG|INFO|WARN|ERROR|FATAL)?
+  log_level: list(debug|info|warn|error|fatal)?

--- a/TeslaBleHttpProxy/config.yaml
+++ b/TeslaBleHttpProxy/config.yaml
@@ -26,5 +26,6 @@ schema:
   vehicle_data_cache_time: int?
   scan_timeout: int?
   log_level: list(debug|info|warn|error|fatal)?
+  external_hostname: str?
   bt_adapter: match(^hci\d+$)?  # Deprecated: kept for backward compatibility, no longer used
   raw_hci: bool?  # Deprecated: kept for backward compatibility, no longer used

--- a/TeslaBleHttpProxy/run.sh
+++ b/TeslaBleHttpProxy/run.sh
@@ -6,6 +6,7 @@ optScanTimeout="$(bashio::config 'scan_timeout' '5')"
 optLogLevel="$(bashio::config 'log_level' 'info')"
 optCacheMaxAge="$(bashio::config 'cache_max_age' '5')"
 optVehicleDataCacheTime="$(bashio::config 'vehicle_data_cache_time' '30')"
+optExternalHostname="$(bashio::config 'external_hostname' 'homeassistant.local')"
 
 # Deprecated options (kept for backward compatibility, but ignored)
 if bashio::config.exists 'bt_adapter'; then
@@ -42,7 +43,7 @@ server {
         proxy_set_header X-Forwarded-Proto \$scheme;
 
         # Rewrite logs link to open in new tab with direct URL
-        sub_filter '<a href="/logs"' '<a href="http://192.168.2.202:$optProxyPort/logs" target="_blank"';
+        sub_filter '<a href="/logs"' '<a href="http://$optExternalHostname:$optProxyPort/logs" target="_blank"';
         sub_filter_once off;
         sub_filter_types text/html;
     }

--- a/TeslaBleHttpProxy/run.sh
+++ b/TeslaBleHttpProxy/run.sh
@@ -31,19 +31,24 @@ server {
     listen $ingressPort;
     allow 172.30.32.2;
     deny all;
+
+    # Redirect root to dashboard
     location = / {
-        proxy_pass http://localhost:$optProxyPort/dashboard;
-        proxy_set_header Host \$host;
-        proxy_set_header X-Real-IP \$remote_addr;
-        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto \$scheme;
+        return 302 /dashboard;
     }
+
+    # Proxy all other requests
     location / {
         proxy_pass http://localhost:$optProxyPort;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host \$host;
+        proxy_set_header X-Forwarded-Port \$server_port;
     }
 }
 EOF

--- a/TeslaBleHttpProxy/run.sh
+++ b/TeslaBleHttpProxy/run.sh
@@ -31,15 +31,8 @@ server {
     listen $ingressPort;
     allow 172.30.32.2;
     deny all;
-
-    # Redirect root to dashboard
-    location = / {
-        return 302 /dashboard;
-    }
-
-    # Proxy all other requests
     location / {
-        proxy_pass http://localhost:$optProxyPort;
+        proxy_pass http://localhost:$optProxyPort/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -47,8 +40,6 @@ server {
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto \$scheme;
-        proxy_set_header X-Forwarded-Host \$host;
-        proxy_set_header X-Forwarded-Port \$server_port;
     }
 }
 EOF

--- a/TeslaBleHttpProxy/run.sh
+++ b/TeslaBleHttpProxy/run.sh
@@ -7,6 +7,14 @@ optLogLevel="$(bashio::config 'log_level' 'info')"
 optCacheMaxAge="$(bashio::config 'cache_max_age' '5')"
 optVehicleDataCacheTime="$(bashio::config 'vehicle_data_cache_time' '30')"
 
+# Deprecated options (kept for backward compatibility, but ignored)
+if bashio::config.exists 'bt_adapter'; then
+    bashio::log.warning "The 'bt_adapter' option is deprecated and no longer used. BlueZ handles adapter selection automatically."
+fi
+if bashio::config.exists 'raw_hci'; then
+    bashio::log.warning "The 'raw_hci' option is deprecated and no longer used. The addon now uses BlueZ by default."
+fi
+
 # Addon information
 selfRepo=$(bashio::addon.repository)
 reportedVersion=$(bashio::addon.version)
@@ -23,8 +31,11 @@ server {
     listen $ingressPort;
     allow 172.30.32.2;
     deny all;
+    location = / {
+        return 301 /dashboard;
+    }
     location / {
-        proxy_pass http://localhost:$optProxyPort/;
+        proxy_pass http://localhost:$optProxyPort;
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
@@ -48,7 +59,7 @@ export cacheMaxAge="$optCacheMaxAge"
 export vehicleDataCacheTime="$optVehicleDataCacheTime"
 export httpListenAddress=":$optProxyPort"
 
-# Change to key directory for the proxy
+# Change to config directory (contains key directory) for the proxy
 cd /data/config
 
 # Start the proxy

--- a/TeslaBleHttpProxy/run.sh
+++ b/TeslaBleHttpProxy/run.sh
@@ -40,6 +40,11 @@ server {
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto \$scheme;
+
+        # Rewrite logs link to open in new tab with direct URL
+        sub_filter '<a href="/logs"' '<a href="http://192.168.2.202:$optProxyPort/logs" target="_blank"';
+        sub_filter_once off;
+        sub_filter_types text/html;
     }
 
     # All paths must be explicitly proxied

--- a/TeslaBleHttpProxy/run.sh
+++ b/TeslaBleHttpProxy/run.sh
@@ -2,11 +2,10 @@
 
 # Read options from the configuration
 optProxyPort="$(bashio::config 'proxy_port' '5667')" # Internal port for the proxy
-optBtAdapter="$(bashio::config 'bt_adapter' 'hci0')"
-optRawHci="$(bashio::config 'raw_hci' 'false')"
-optScanTimeout="$(bashio::config 'scan_timeout' '1')"
-optLogLevel="$(bashio::config 'log_level' 'INFO')"
+optScanTimeout="$(bashio::config 'scan_timeout' '5')"
+optLogLevel="$(bashio::config 'log_level' 'info')"
 optCacheMaxAge="$(bashio::config 'cache_max_age' '5')"
+optVehicleDataCacheTime="$(bashio::config 'vehicle_data_cache_time' '30')"
 
 # Addon information
 selfRepo=$(bashio::addon.repository)
@@ -37,29 +36,20 @@ EOF
 # Start nginx
 nginx -c /etc/nginx/nginx.conf
 
+# Create key directory
 mkdir -p /data/config/key
 
-if [ $optRawHci = "true" ]; then
-    TeslaBleHttpProxyBin=/usr/local/bin/TeslaBleHttpProxy
-    adapterInfo="using HCI"
-else
-    TeslaBleHttpProxyBin=/usr/local/bin/TeslaBleHttpProxy-BlueZ
-    adapterInfo="using BlueZ"
-fi
+bashio::log.info "Starting TeslaBleHttpProxy v$reportedVersion"
 
-btAdapter=""
-if [ -n "$optBtAdapter" ] && [ "$optBtAdapter" != "null" ]; then
-    btAdapter="--btAdapter=$optBtAdapter"
-    adapterInfo="$adapterInfo ($optBtAdapter)"
-fi
+# Export environment variables for TeslaBleHttpProxy
+export logLevel="$optLogLevel"
+export scanTimeout="$optScanTimeout"
+export cacheMaxAge="$optCacheMaxAge"
+export vehicleDataCacheTime="$optVehicleDataCacheTime"
+export httpListenAddress=":$optProxyPort"
 
-bashio::log.info "Starting TeslaBleHttpProxy v$reportedVersion $adapterInfo"
+# Change to key directory for the proxy
+cd /data/config
 
 # Start the proxy
-$TeslaBleHttpProxyBin \
-    --scanTimeout=$optScanTimeout \
-    --logLevel=$optLogLevel \
-    --keys=/data/config/key \
-    --cacheMaxAge=$optCacheMaxAge \
-    $btAdapter \
-    --httpListenAddress=":$optProxyPort"
+/usr/local/bin/TeslaBleHttpProxy

--- a/TeslaBleHttpProxy/run.sh
+++ b/TeslaBleHttpProxy/run.sh
@@ -31,8 +31,20 @@ server {
     listen $ingressPort;
     allow 172.30.32.2;
     deny all;
+
+    # Root shows dashboard
+    location = / {
+        proxy_pass http://localhost:$optProxyPort/dashboard;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+
+    # All other paths
     location / {
-        proxy_pass http://localhost:$optProxyPort/;
+        proxy_pass http://localhost:$optProxyPort;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/TeslaBleHttpProxy/run.sh
+++ b/TeslaBleHttpProxy/run.sh
@@ -42,9 +42,9 @@ server {
         proxy_set_header X-Forwarded-Proto \$scheme;
     }
 
-    # All other paths
-    location / {
-        proxy_pass http://localhost:$optProxyPort;
+    # All paths must be explicitly proxied
+    location ~ ^/(dashboard|logs|api|static|gen_keys|remove_keys|add_key_to_vehicle|switch_role) {
+        proxy_pass http://localhost:$optProxyPort\$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/TeslaBleHttpProxy/run.sh
+++ b/TeslaBleHttpProxy/run.sh
@@ -32,7 +32,11 @@ server {
     allow 172.30.32.2;
     deny all;
     location = / {
-        return 301 /dashboard;
+        proxy_pass http://localhost:$optProxyPort/dashboard;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
     }
     location / {
         proxy_pass http://localhost:$optProxyPort;


### PR DESCRIPTION
## Summary
This PR updates the TeslaBleHttpProxy addon to version 2.3.0 from the official wimaha/TeslaBleHttpProxy upstream repository.

## Changes
- Update upstream repository from Lenart12 to wimaha/TeslaBleHttpProxy
- Upgrade TeslaBleHttpProxy from version 0.2.1 to 2.3.0
- Add support for role-based key system (Owner and Charging Manager roles)
- Add `vehicle_data_cache_time` configuration option for in-memory caching
- Switch from command-line flags to environment variable configuration
- Remove deprecated `bt_adapter` and `raw_hci` options (BlueZ is now used by default)
- Simplify Dockerfile by removing dual-binary build
- Update default `scan_timeout` from 1 to 5 seconds
- Update log level values to lowercase format

## New Features in 2.3.0
- **Role-based key system**: Support for Owner and Charging Manager roles for better security
- **Vehicle data caching**: New in-memory cache for VehicleData endpoints (default: 30 seconds)
- **Improved configuration**: Environment variable-based configuration matching upstream
- **Auto-migration**: Legacy keys automatically migrated to Owner role on startup

## Testing
- ✅ Addon builds successfully
- ✅ Keys migrate from old version automatically
- ✅ BLE communication with Tesla working
- ✅ All commands tested and working
- ✅ Dashboard accessible and functional

## Benefits
- Keeps addon in sync with official wimaha upstream
- Users get latest features and security improvements
- Better security with role-based access control
- Improved caching reduces BLE connections